### PR TITLE
Fix PromptTemplate usage in example

### DIFF
--- a/rag_pipeline_demo.py
+++ b/rag_pipeline_demo.py
@@ -25,7 +25,6 @@ document_store.update_embeddings(retriever)
 
 # 3. Define prompt template
 prompt_template = PromptTemplate(
-    name="finance_qa",
     prompt="""
 Given these documents:\n{join(documents)}\n\nAnswer the question: {query}
 """,


### PR DESCRIPTION
## Summary
- use PromptTemplate without deprecated `name` arg

## Testing
- `python rag_pipeline_demo.py` *(fails: ModuleNotFoundError: No module named 'haystack')*

------
https://chatgpt.com/codex/tasks/task_e_684858e8dd8c833283a53732a3d66e2d